### PR TITLE
fix: supporting old schema for retrocompatibility

### DIFF
--- a/src/get-serializers.ts
+++ b/src/get-serializers.ts
@@ -12,9 +12,10 @@ export type AvroTreeKeyCacheOptions<TValue extends object> = Required<
 
 export function getAvroSerializers<TValue extends object>(
 	schema: Schema,
+	previousSchema?: Schema,
 ): AvroTreeKeyCacheOptions<TValue> {
 	return {
 		treeSerializer: AvroTreeSerializer.getInstance(),
-		valueSerializer: AvroValueSerializer.getInstance(schema),
+		valueSerializer: AvroValueSerializer.getInstance(schema, previousSchema),
 	};
 }

--- a/src/get-serializers.ts
+++ b/src/get-serializers.ts
@@ -12,10 +12,10 @@ export type AvroTreeKeyCacheOptions<TValue extends object> = Required<
 
 export function getAvroSerializers<TValue extends object>(
 	schema: Schema,
-	previousSchema?: Schema,
+	previousSchemas?: Schema[],
 ): AvroTreeKeyCacheOptions<TValue> {
 	return {
 		treeSerializer: AvroTreeSerializer.getInstance(),
-		valueSerializer: AvroValueSerializer.getInstance(schema, previousSchema),
+		valueSerializer: AvroValueSerializer.getInstance(schema, previousSchemas),
 	};
 }

--- a/src/load-avro-type.ts
+++ b/src/load-avro-type.ts
@@ -2,14 +2,18 @@ import { Resolver, Schema, Type } from 'avsc';
 
 export function loadAvroType(
 	avroSchema: Schema,
-	previousSchema?: Schema,
-): { type: Type; resolver: Resolver | undefined } {
+	previousSchemas: Schema[] | undefined,
+): { type: Type; resolvers: Resolver[] } {
 	const type = Type.forSchema(avroSchema, {
 		omitRecordMethods: true,
 	});
-	const resolver = previousSchema
-		? type.createResolver(Type.forSchema(previousSchema))
-		: undefined;
+	const resolvers: Resolver[] = [];
+	if (previousSchemas) {
+		for (const previousSchema of previousSchemas) {
+			const resolver = type.createResolver(Type.forSchema(previousSchema));
+			resolvers.push(resolver);
+		}
+	}
 
-	return { type, resolver };
+	return { type, resolvers };
 }

--- a/src/load-avro-type.ts
+++ b/src/load-avro-type.ts
@@ -1,7 +1,15 @@
-import avro, { Schema } from 'avsc';
+import { Resolver, Schema, Type } from 'avsc';
 
-export function loadAvroType(avroSchema: Schema) {
-	return avro.Type.forSchema(avroSchema, {
+export function loadAvroType(
+	avroSchema: Schema,
+	previousSchema?: Schema,
+): { type: Type; resolver: Resolver | undefined } {
+	const type = Type.forSchema(avroSchema, {
 		omitRecordMethods: true,
 	});
+	const resolver = previousSchema
+		? type.createResolver(Type.forSchema(previousSchema))
+		: undefined;
+
+	return { type, resolver };
 }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,16 +1,19 @@
-import { Type } from 'avsc/types';
+import { Resolver, Type } from 'avsc/types';
 import { Serializer } from 'tree-key-cache';
 
 export class AvroSerializer<TValue extends object>
 	implements Serializer<TValue, Buffer>
 {
-	protected constructor(private readonly type: Type) {}
+	protected constructor(
+		private readonly type: Type,
+		private readonly resolver?: Resolver,
+	) {}
 
 	serialize(a: TValue): Buffer {
 		return this.type.toBuffer(a);
 	}
 
 	deserialize(b: Buffer): TValue {
-		return this.type.decode(b).value as TValue;
+		return this.type.decode(b, 0, this.resolver).value as TValue;
 	}
 }

--- a/src/tree-serializer.ts
+++ b/src/tree-serializer.ts
@@ -5,8 +5,8 @@ import { treeSchema } from './tree-schema';
 
 export class AvroTreeSerializer extends AvroSerializer<Tree<Buffer>> {
 	static getInstance() {
-		const type = loadAvroType(treeSchema);
+		const { type, resolver } = loadAvroType(treeSchema);
 
-		return new AvroTreeSerializer(type);
+		return new AvroTreeSerializer(type, resolver);
 	}
 }

--- a/src/tree-serializer.ts
+++ b/src/tree-serializer.ts
@@ -5,8 +5,8 @@ import { treeSchema } from './tree-schema';
 
 export class AvroTreeSerializer extends AvroSerializer<Tree<Buffer>> {
 	static getInstance() {
-		const { type, resolver } = loadAvroType(treeSchema);
+		const { type, resolvers } = loadAvroType(treeSchema, undefined);
 
-		return new AvroTreeSerializer(type, resolver);
+		return new AvroTreeSerializer(type, resolvers);
 	}
 }

--- a/src/value-serializer.ts
+++ b/src/value-serializer.ts
@@ -7,10 +7,10 @@ export class AvroValueSerializer<
 > extends AvroSerializer<TValue> {
 	static getInstance<TValue extends object>(
 		schema: Schema,
-		readerSchema: Schema | undefined,
+		previousSchemas: Schema[] | undefined,
 	) {
-		const { type, resolver } = loadAvroType(schema, readerSchema);
+		const { type, resolvers } = loadAvroType(schema, previousSchemas);
 
-		return new AvroValueSerializer<TValue>(type, resolver);
+		return new AvroValueSerializer<TValue>(type, resolvers);
 	}
 }

--- a/src/value-serializer.ts
+++ b/src/value-serializer.ts
@@ -5,9 +5,12 @@ import { AvroSerializer } from './serializer';
 export class AvroValueSerializer<
 	TValue extends object,
 > extends AvroSerializer<TValue> {
-	static getInstance<TValue extends object>(schema: Schema) {
-		const type = loadAvroType(schema);
+	static getInstance<TValue extends object>(
+		schema: Schema,
+		readerSchema: Schema | undefined,
+	) {
+		const { type, resolver } = loadAvroType(schema, readerSchema);
 
-		return new AvroValueSerializer<TValue>(type);
+		return new AvroValueSerializer<TValue>(type, resolver);
 	}
 }

--- a/test/unit/avro.spec.ts
+++ b/test/unit/avro.spec.ts
@@ -28,7 +28,7 @@ describe('avro', () => {
 				},
 			},
 		};
-		const { type } = loadAvroType(treeSchema);
+		const { type } = loadAvroType(treeSchema, undefined);
 
 		const encoded = type.toBuffer(tree);
 		const decoded = type.fromBuffer(encoded);

--- a/test/unit/avro.spec.ts
+++ b/test/unit/avro.spec.ts
@@ -28,7 +28,7 @@ describe('avro', () => {
 				},
 			},
 		};
-		const type = loadAvroType(treeSchema);
+		const { type } = loadAvroType(treeSchema);
 
 		const encoded = type.toBuffer(tree);
 		const decoded = type.fromBuffer(encoded);

--- a/test/unit/tree-key-cache.spec.ts
+++ b/test/unit/tree-key-cache.spec.ts
@@ -5,7 +5,6 @@ import {
 } from '../../src';
 import { Step, Tree, TreeKeyCache, TreeKeys } from 'tree-key-cache';
 import { promisify } from 'util';
-import { loadAvroType } from 'src/load-avro-type';
 import { Schema } from 'avsc/types';
 
 const delay = promisify(setTimeout);
@@ -25,8 +24,7 @@ const schema: Schema = {
 
 class MyValueSerializer extends AvroValueSerializer<{ value: number }> {
 	static load() {
-		const valueProto = loadAvroType(schema);
-		return MyValueSerializer.getInstance<{ value: number }>(valueProto);
+		return MyValueSerializer.getInstance<{ value: number }>(schema, undefined);
 	}
 }
 


### PR DESCRIPTION
If the user wants to evolve a previous payload to a new one, like, adding some fields or making compatible type changes, avro requires that a resolver is created for the previous schema.

This change allows the user to do that